### PR TITLE
feat: ensure bankid pages respect the theme set on client-id

### DIFF
--- a/src/main/java/org/keycloak/broker/bankid/BankidEndpoint.java
+++ b/src/main/java/org/keycloak/broker/bankid/BankidEndpoint.java
@@ -38,6 +38,8 @@ import org.keycloak.connections.infinispan.InfinispanConnectionProvider;
 import org.keycloak.forms.login.LoginFormsProvider;
 import org.keycloak.models.IdentityProviderModel;
 import org.keycloak.sessions.AuthenticationSessionModel;
+import org.keycloak.services.managers.AuthenticationSessionManager;
+import org.keycloak.sessions.RootAuthenticationSessionModel;
 
 import com.google.zxing.BarcodeFormat;
 import com.google.zxing.client.j2se.MatrixToImageWriter;
@@ -71,24 +73,25 @@ public class BankidEndpoint {
 		this.actionTokenCache = infinispanConnectionProvider.getCache(InfinispanConnectionProvider.ACTION_TOKEN_CACHE);
 	}
 
-	@GET
-	@Path("/start")
-	public Response start(@QueryParam("state") String state) {
+@GET
+    @Path("/start")
+    public Response start(@QueryParam("state") String state) {
 
-		if (state == null) {
-			return callback.error(config, "bankid.hints." + BankidHintCodes.internal.messageShortName);
-		}
+        if (state == null) {
+            return callback.error(config, "bankid.hints." + BankidHintCodes.internal.messageShortName);
+        }
 
-		if (config.isRequiredNin()) {
-			LoginFormsProvider loginFormsProvider = provider.getSession().getProvider(LoginFormsProvider.class);
-			return loginFormsProvider
-					.setAttribute("state", state)
-					.createForm("start-bankid.ftl");
-		} else {
-			// Go direct to login if we do not require non.
-			return doLogin(null, state);
-		}
-	}
+        if (config.isRequiredNin()) {
+            LoginFormsProvider loginFormsProvider = provider.getSession().getProvider(LoginFormsProvider.class);
+            applyClientSessionContext(loginFormsProvider, state);
+            return loginFormsProvider
+                    .setAttribute("state", state)
+                    .createForm("start-bankid.ftl");
+        } else {
+						// Go direct to login if we do not require non.
+            return doLogin(null, state);
+        }
+    }
 
 	@POST
 	@Path("/login")
@@ -104,7 +107,8 @@ public class BankidEndpoint {
 
 	private Response doLogin(String nin, String state) {
 		LoginFormsProvider loginFormsProvider = provider.getSession().getProvider(LoginFormsProvider.class);
-
+		applyClientSessionContext(loginFormsProvider, state);
+		
 		try {
 			AuthResponse authResponse;
 			authResponse = bankidClient.sendAuth(nin, provider.getSession().getContext().getConnection().getRemoteAddr());
@@ -216,9 +220,10 @@ public class BankidEndpoint {
 
 	@GET
 	@Path("/cancel")
-	public Response cancel(@QueryParam("bankidref") String bankidRef) {
+	public Response cancel(@QueryParam("bankidref") String bankidRef, @QueryParam("state") String state) {		
 		LoginFormsProvider loginFormsProvider = provider.getSession().getProvider(LoginFormsProvider.class);
-
+		applyClientSessionContext(loginFormsProvider, state);
+	
 		if (!this.actionTokenCache.containsKey(bankidRef) ||
 				!(this.actionTokenCache.get(bankidRef) instanceof AuthResponse)) {
 			return loginFormsProvider.setError("bankid.error.internal").createErrorPage(Status.INTERNAL_SERVER_ERROR);
@@ -240,8 +245,8 @@ public class BankidEndpoint {
 
 	@GET
 	@Path("/error")
-	public Response error(@QueryParam("code") String hintCode) {
-
+	public Response error(@QueryParam("code") String hintCode, @QueryParam("state") String state) {
+	
 		BankidHintCodes hint;
 		// Sanitize input from the web
 		try {
@@ -250,6 +255,7 @@ public class BankidEndpoint {
 			hint = BankidHintCodes.unkown;
 		}
 		LoginFormsProvider loginFormsProvider = provider.getSession().getProvider(LoginFormsProvider.class);
+		applyClientSessionContext(loginFormsProvider, state);
 		return loginFormsProvider.setError("bankid.hints." + hint.messageShortName)
 				.createErrorPage(Status.INTERNAL_SERVER_ERROR);
 	}
@@ -317,4 +323,35 @@ public class BankidEndpoint {
 
 		return String.format("%064x", new BigInteger(1, mac.doFinal(new String(time).getBytes())));
 	}
+	
+	/**
+     * Passively resolves the client session context from the 'state' parameter.
+     * This allows the correct client theme to be rendered without consuming
+     * the cryptographic nonce, avoiding 500 errors in the broker flow.
+     */
+    private void applyClientSessionContext(LoginFormsProvider loginFormsProvider, String state) {
+        if (state == null || !state.contains(".")) return;
+        
+        try {
+            String[] parts = state.split("\\.");
+            if (parts.length >= 2) {
+                String tabId = parts[1];
+                
+                AuthenticationSessionManager asm = new AuthenticationSessionManager(provider.getSession());
+                RootAuthenticationSessionModel rootSession = asm.getCurrentRootAuthenticationSession(provider.getSession().getContext().getRealm());
+                
+                if (rootSession != null && tabId != null) {
+                    for (AuthenticationSessionModel session : rootSession.getAuthenticationSessions().values()) {
+                        if (tabId.equals(session.getTabId())) {
+                            loginFormsProvider.setAuthenticationSession(session);
+                            provider.getSession().getContext().setClient(session.getClient());
+                            return;
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            logger.warn("Could not apply client session context for theme", e);
+        }
+    }
 }

--- a/src/main/java/org/keycloak/broker/bankid/BankidEndpoint.java
+++ b/src/main/java/org/keycloak/broker/bankid/BankidEndpoint.java
@@ -73,25 +73,25 @@ public class BankidEndpoint {
 		this.actionTokenCache = infinispanConnectionProvider.getCache(InfinispanConnectionProvider.ACTION_TOKEN_CACHE);
 	}
 
-@GET
-    @Path("/start")
-    public Response start(@QueryParam("state") String state) {
+	@GET
+	@Path("/start")
+	public Response start(@QueryParam("state") String state) {
 
-        if (state == null) {
-            return callback.error(config, "bankid.hints." + BankidHintCodes.internal.messageShortName);
-        }
+		if (state == null) {
+			return callback.error(config, "bankid.hints." + BankidHintCodes.internal.messageShortName);
+		}
 
-        if (config.isRequiredNin()) {
-            LoginFormsProvider loginFormsProvider = provider.getSession().getProvider(LoginFormsProvider.class);
-            applyClientSessionContext(loginFormsProvider, state);
-            return loginFormsProvider
-                    .setAttribute("state", state)
-                    .createForm("start-bankid.ftl");
-        } else {
-						// Go direct to login if we do not require non.
-            return doLogin(null, state);
-        }
-    }
+		if (config.isRequiredNin()) {
+			LoginFormsProvider loginFormsProvider = provider.getSession().getProvider(LoginFormsProvider.class);
+			applyClientSessionContext(loginFormsProvider, state);
+			return loginFormsProvider
+					.setAttribute("state", state)
+					.createForm("start-bankid.ftl");
+		} else {
+			// Go direct to login if we do not require non.
+			return doLogin(null, state);
+		}
+	}
 
 	@POST
 	@Path("/login")
@@ -108,10 +108,11 @@ public class BankidEndpoint {
 	private Response doLogin(String nin, String state) {
 		LoginFormsProvider loginFormsProvider = provider.getSession().getProvider(LoginFormsProvider.class);
 		applyClientSessionContext(loginFormsProvider, state);
-		
+
 		try {
 			AuthResponse authResponse;
-			authResponse = bankidClient.sendAuth(nin, provider.getSession().getContext().getConnection().getRemoteAddr());
+			authResponse = bankidClient.sendAuth(nin,
+					provider.getSession().getContext().getConnection().getRemoteAddr());
 
 			UUID bankidRef = UUID.randomUUID();
 			this.actionTokenCache.put(bankidRef.toString(), authResponse, MAX_CACHE_LIFESPAN, TimeUnit.MINUTES);
@@ -220,10 +221,10 @@ public class BankidEndpoint {
 
 	@GET
 	@Path("/cancel")
-	public Response cancel(@QueryParam("bankidref") String bankidRef, @QueryParam("state") String state) {		
+	public Response cancel(@QueryParam("bankidref") String bankidRef, @QueryParam("state") String state) {
 		LoginFormsProvider loginFormsProvider = provider.getSession().getProvider(LoginFormsProvider.class);
 		applyClientSessionContext(loginFormsProvider, state);
-	
+
 		if (!this.actionTokenCache.containsKey(bankidRef) ||
 				!(this.actionTokenCache.get(bankidRef) instanceof AuthResponse)) {
 			return loginFormsProvider.setError("bankid.error.internal").createErrorPage(Status.INTERNAL_SERVER_ERROR);
@@ -246,7 +247,7 @@ public class BankidEndpoint {
 	@GET
 	@Path("/error")
 	public Response error(@QueryParam("code") String hintCode, @QueryParam("state") String state) {
-	
+
 		BankidHintCodes hint;
 		// Sanitize input from the web
 		try {
@@ -323,35 +324,37 @@ public class BankidEndpoint {
 
 		return String.format("%064x", new BigInteger(1, mac.doFinal(new String(time).getBytes())));
 	}
-	
+
 	/**
-     * Passively resolves the client session context from the 'state' parameter.
-     * This allows the correct client theme to be rendered without consuming
-     * the cryptographic nonce, avoiding 500 errors in the broker flow.
-     */
-    private void applyClientSessionContext(LoginFormsProvider loginFormsProvider, String state) {
-        if (state == null || !state.contains(".")) return;
-        
-        try {
-            String[] parts = state.split("\\.");
-            if (parts.length >= 2) {
-                String tabId = parts[1];
-                
-                AuthenticationSessionManager asm = new AuthenticationSessionManager(provider.getSession());
-                RootAuthenticationSessionModel rootSession = asm.getCurrentRootAuthenticationSession(provider.getSession().getContext().getRealm());
-                
-                if (rootSession != null && tabId != null) {
-                    for (AuthenticationSessionModel session : rootSession.getAuthenticationSessions().values()) {
-                        if (tabId.equals(session.getTabId())) {
-                            loginFormsProvider.setAuthenticationSession(session);
-                            provider.getSession().getContext().setClient(session.getClient());
-                            return;
-                        }
-                    }
-                }
-            }
-        } catch (Exception e) {
-            logger.warn("Could not apply client session context for theme", e);
-        }
-    }
+	 * Passively resolves the client session context from the 'state' parameter.
+	 * This allows the correct client theme to be rendered without consuming
+	 * the cryptographic nonce, avoiding 500 errors in the broker flow.
+	 */
+	private void applyClientSessionContext(LoginFormsProvider loginFormsProvider, String state) {
+		if (state == null || !state.contains("."))
+			return;
+
+		try {
+			String[] parts = state.split("\\.");
+			if (parts.length >= 2) {
+				String tabId = parts[1];
+
+				AuthenticationSessionManager asm = new AuthenticationSessionManager(provider.getSession());
+				RootAuthenticationSessionModel rootSession = asm
+						.getCurrentRootAuthenticationSession(provider.getSession().getContext().getRealm());
+
+				if (rootSession != null && tabId != null) {
+					for (AuthenticationSessionModel session : rootSession.getAuthenticationSessions().values()) {
+						if (tabId.equals(session.getTabId())) {
+							loginFormsProvider.setAuthenticationSession(session);
+							provider.getSession().getContext().setClient(session.getClient());
+							return;
+						}
+					}
+				}
+			}
+		} catch (Exception e) {
+			logger.warn("Could not apply client session context for theme", e);
+		}
+	}
 }

--- a/src/main/resources/theme-resources/resources/js/bankid.js
+++ b/src/main/resources/theme-resources/resources/js/bankid.js
@@ -25,11 +25,13 @@ function redirectToDone(bankidref, state) {
 }
 
 function redirectToError(errorCode) {
-	window.location.href = "error?code=" + errorCode;
+    const stateVal = document.getElementById('state') ? document.getElementById('state').value : '';
+    window.location.href = "error?code=" + errorCode + "&state=" + stateVal;
 }
 
 function redirectToCancel(errorCode, bankidref) {
-	window.location.href = "cancel?bankidref=" + bankidref;
+    const stateVal = document.getElementById('state') ? document.getElementById('state').value : '';
+    window.location.href = "cancel?bankidref=" + bankidref + "&state=" + stateVal;
 }
 
 /* For login form */

--- a/src/main/resources/theme-resources/templates/login-bankid.ftl
+++ b/src/main/resources/theme-resources/templates/login-bankid.ftl
@@ -43,6 +43,7 @@
 			</div>
 			<form novalidate="" action="cancel">
 			<input id="bankidref" name="bankidref" autocorrect="off" autocomplete="off" type="hidden" value="${bankidref}" />
+			<input id="state" name="state" type="hidden" value="${state}" />
 			<button
 				style="padding: 0px; margin: 0px; background-color: rgba(255, 255, 255, 0); border: medium none; cursor: pointer; outline: currentcolor none medium;">
 				<div


### PR DESCRIPTION
**Problem**
Currently, BankID broker endpoints default to the Realm-level theme because the client context is lost during the identity provider redirection.

**What i did**
This PR introduces a passive resolution of the client session context using the state parameter. By extracting the tab_id from the state, we can identify the correct AuthenticationSession and apply its associated client theme to the LoginFormsProvider and global KeycloakContext.

Includes /start, /login, /cancel, and /error to maintain branding throughout the entire BankID lifecycle.

**i have tested the following:**
Verified that the correct client-id theme is applied when explicitly set.
Verified fallback to realm theme when no client-id theme is defined.
Verified that the main login flow completes successfully.