### PR TITLE
Potential fix for code scanning alert no. 5: DOM text reinterpreted as HTML

### DIFF
--- a/src/main/resources/theme-resources/resources/js/bankid.js
+++ b/src/main/resources/theme-resources/resources/js/bankid.js
@@ -26,12 +26,12 @@ function redirectToDone(bankidref, state) {
 
 function redirectToError(errorCode) {
     const stateVal = document.getElementById('state') ? document.getElementById('state').value : '';
-    window.location.href = "error?code=" + errorCode + "&state=" + stateVal;
+    window.location.href = "error?code=" + encodeURIComponent(errorCode) + "&state=" + encodeURIComponent(stateVal);
 }
 
 function redirectToCancel(errorCode, bankidref) {
     const stateVal = document.getElementById('state') ? document.getElementById('state').value : '';
-    window.location.href = "cancel?bankidref=" + bankidref + "&state=" + stateVal;
+    window.location.href = "cancel?bankidref=" + encodeURIComponent(bankidref) + "&state=" + encodeURIComponent(stateVal);
 }
 
 /* For login form */


### PR DESCRIPTION
Potential fix for [https://github.com/sweid4keycloak/bankid4keycloak/security/code-scanning/5](https://github.com/sweid4keycloak/bankid4keycloak/security/code-scanning/5)

In general, when taking text from the DOM and using it in a URL or any context that might later be interpreted as HTML or JavaScript, the value should be encoded appropriately for that context. For query parameters in a URL, the correct encoding is URL encoding (for example using `encodeURIComponent`), which ensures that meta-characters cannot break out of the parameter value.

For this specific code, the best minimal fix is to apply `encodeURIComponent` to the `stateVal` (and, for consistency and safety, to `errorCode` as well) before concatenating them into the query string for `window.location.href`. This keeps the functional behavior (the server still receives the same logical values, but now properly encoded) while eliminating the possibility that special characters in `stateVal` or `errorCode` will interfere with URL parsing or be reinterpreted unsafely downstream. No imports are needed; `encodeURIComponent` is a standard built-in function.

Concretely:
- In `redirectToError`, change line 29 so that both `errorCode` and `stateVal` are passed through `encodeURIComponent`.
- In `redirectToCancel`, change line 34 similarly for `bankidref` and `stateVal`. While only `stateVal` was highlighted, encoding all dynamic query parameters is safer and consistent, and does not change intent.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
