### PR TITLE
Upgrading keycloak deps to 26.7.0 and protostream to 6.0.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,9 +12,9 @@
 		<java.version>21</java.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
-		<keycloak.version>26.5.6</keycloak.version>
+		<keycloak.version>26.7.0</keycloak.version>
 		<google.zxing.version>3.5.3</google.zxing.version>
-		<protostream.version>15.0.13.Final</protostream.version>
+		<protostream.version>6.0.9</protostream.version>
 	</properties>
 	<licenses>
 		<license>

--- a/src/main/java/org/keycloak/broker/bankid/BankidIdentityProvider.java
+++ b/src/main/java/org/keycloak/broker/bankid/BankidIdentityProvider.java
@@ -15,6 +15,7 @@ import org.keycloak.models.FederatedIdentityModel;
 import org.keycloak.models.KeycloakSession;
 import org.keycloak.models.RealmModel;
 import org.keycloak.models.UserModel;
+import org.keycloak.models.UserSessionModel;
 
 public class BankidIdentityProvider extends AbstractIdentityProvider<BankidIdentityProviderConfig> {
 
@@ -47,7 +48,14 @@ public class BankidIdentityProvider extends AbstractIdentityProvider<BankidIdent
 	}
 
 	@Override
+	@Deprecated
 	public Response retrieveToken(KeycloakSession session, FederatedIdentityModel identity) {
+		return retrieveToken(session, identity, null, null);
+	}
+
+	@Override
+	public Response retrieveToken(KeycloakSession session, FederatedIdentityModel identity,
+			UserSessionModel userSession, UserModel user) {
 		return Response.ok(identity.getToken()).build();
 	}
 


### PR DESCRIPTION
Upgrading keycloak and protostream dependencies to 26.7.0 and 6.0.9 respectively.

Updated BankidIdentityProvider to implement the new retrieveToken.